### PR TITLE
[FIX] update logic localProperties not make error at CI/CD environment

### DIFF
--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -7,7 +7,10 @@ plugins {
 }
 
 val localProperties = Properties().apply {
-    load(rootProject.file("local.properties").inputStream())
+    val localFile = File(rootDir, "local.properties")
+    if (localFile.exists()) {
+        load(localFile.inputStream())
+    }
 }
 
 android {


### PR DESCRIPTION
## 작업 배경
/home/runner/work/todolist_android/todolist_android/local.properties (No such file or directory)

## 작업 사항
- CI/CD 환경에서의 빌드를 위해 LocalProperties가 있는지 확인하고 불러오도록 설정