### PR TITLE
[FIX] make todolist_keystore path valid

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build AAB
         run: ./gradlew clean bundleRelease
         env:
-          KEYSTORE_FILE: todolist_keystore.jks
+          KEYSTORE_FILE: ../todolist_keystore.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}


### PR DESCRIPTION
## 작업 배경
 Keystore file 'presentation/todolist_***store.jks' not found for signing config 'release'.

## 작업 사항
- 루트 디렉토리에 keystore를 두기 때문에 env 설정 시에 루트 경로로 찾도록 변경
