### PR TITLE
[FIX] add env at Run Fastlane deploy stage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,4 +55,8 @@ jobs:
         run: fastlane deploy
         env:
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}  # GitHub Secrets에 저장한 Google Play JSON 키
+          KEYSTORE_FILE: ../todolist_keystore.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 #          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}  # GitHub Secrets에 저장한 Slack Webhook URL


### PR DESCRIPTION
## 작업 배경 
System.getenv("KEYSTORE_…Property("KEYSTORE_FILE") must not be null
=> Run Fastlane deploy step에서 그전 env가 적용되지 않아 읽히지 않았던 문제

## 작업 사항
- Run Fastlane deploy step에도 env 적용