### PR TITLE
[RELEASE] make fastlane skip upload metadata

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,6 +39,8 @@ platform :android do
         aab: "presentation/build/outputs/bundle/release/presentation-release.aab",  # AAB 파일 경로
         track: "production",  # 배포 트랙: production, beta 등
         json_key_data: ENV["GOOGLE_PLAY_JSON_KEY"],  # 서비스 계정의 JSON 키 데이터를 환경 변수로 전달
+        skip_upload_metadata: true,
+        skip_upload_changelogs: false,
         metadata_path: "./fastlane/metadata"
     )
 


### PR DESCRIPTION
## 작업 배경
android - Invalid request

## 작업 사항
- metadata만 업로드 하지 않고 changelog만 업로드 하도록 변경

## 패치 노트
패치 노트가 정상적으로 업로드 되었습니다.