### PR TITLE
[RELEASE] add ENVs at generating versionCode step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,11 @@ jobs:
           # 3) changelog 파일 생성
           mkdir -p fastlane/metadata/android/ko/changelogs
           echo "$NOTES" > fastlane/metadata/android/ko/changelogs/${CODE}.txt
+        env:
+          KEYSTORE_FILE: ../todolist_keystore.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       # 2. JDK 설정 (필요한 Java 버전 지정)
       - name: Set up JDK


### PR DESCRIPTION
### **User description**
## 작업 배경
System.getenv("KEYSTORE_…Property("KEYSTORE_FILE") must not be null

## 작업 사항
- versionCode를 만드는 단계에 환경변수 추가

## 패치 노트
성공적으로 자동 배포가 완료되었습니다.


___

### **PR Type**
enhancement


___

### **Description**
- Add required environment variables to versionCode generation step

- Improve CI/CD workflow reliability for Android deployment


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add keystore-related environment variables to deploy workflow</code></dd></summary>
<hr>

.github/workflows/deploy.yml

<li>Added <code>KEYSTORE_FILE</code>, <code>KEYSTORE_PASSWORD</code>, <code>KEY_ALIAS</code>, and <code>KEY_PASSWORD</code> as <br>environment variables to the versionCode generation step.<br> <li> Ensured secrets are used for sensitive values in the workflow.<br> <li> Improved automation for changelog and deployment steps.


</details>


  </td>
  <td><a href="https://github.com/PARAOOO/todolist_android/pull/38/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>